### PR TITLE
Adding the possibility to specify the runtime in the function block

### DIFF
--- a/deploy/lib/createFunctions.js
+++ b/deploy/lib/createFunctions.js
@@ -28,9 +28,6 @@ module.exports = {
   },
 
   createSingleFunction(func) {
-    const message = `this -> ${this.runtime} and func ->  ${func.runtime}`;
-    this.serverless.cli.log(`${message}`)
-
     const params = {
       name: func.name,
       environment_variables: func.env,

--- a/deploy/lib/createFunctions.js
+++ b/deploy/lib/createFunctions.js
@@ -28,6 +28,9 @@ module.exports = {
   },
 
   createSingleFunction(func) {
+    const message = `this -> ${this.runtime} and func ->  ${func.runtime}`;
+    this.serverless.cli.log(`${message}`)
+
     const params = {
       name: func.name,
       environment_variables: func.env,
@@ -35,7 +38,7 @@ module.exports = {
       memory_limit: func.memoryLimit,
       min_scale: func.minScale,
       max_scale: func.maxScale,
-      runtime: this.runtime,
+      runtime: func.runtime || this.runtime,
       timeout: func.timeout,
       handler: func.handler,
       privacy: func.privacy,

--- a/docs/README.md
+++ b/docs/README.md
@@ -155,7 +155,10 @@ You may use the [container example](../examples/container) to getting started.
 
 ### Runtime and Functions Handler
 
-You must specify a default function'runtime inside `provider.runtime` key inside your serverless.yml file. If you want a specif runtime for a specific function you can define it inside `functions.myfunction.runtime` key.  
+You must specify a default function'runtime inside `provider.runtime` key inside your serverless.yml file.  
+
+If you want to use a different runtime for a specific function, you may define the runtime you wish to use inside functions.myfunction.runtime. This way, you may use the same serverless project to deploy functions written in different languages.
+
 It is not necessary if you wish to deploy containers only.
 
 #### Runtimes

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,6 +91,8 @@ provider:
   # python (2.7), python3 (3.7) for Python
   # golang
   # You don't need to specify a runtime if you deploy only containers
+  # This is the default runtime for your functions
+  # You can define a specific runtime for each function
   runtime: <runtime>
   # See documentation below for environment
   env:
@@ -105,8 +107,10 @@ provider:
 ```yml
 functions:
   myFunction:
-    # handler may vary for each runtimes (e.g in golang, references package while python/node references handler file).
+    # handler may vary for each runtimes (e.g in golang, references package while python/node references handler file).    
     handler: path/to/handler/file
+    # Optional runtime if same as the default runtime
+    runtime: <runtime> 
     # Environment only available in this function
     env:
       MY_VARIABLE: "my-value"
@@ -151,7 +155,8 @@ You may use the [container example](../examples/container) to getting started.
 
 ### Runtime and Functions Handler
 
-You must specify your functions runtime inside `provider.runtime` key inside your serverless.yml file. It is not necessary if you wish to deploy containers only.
+You must specify a default function'runtime inside `provider.runtime` key inside your serverless.yml file. If you want a specif runtime for a specific function you can define it inside `functions.myfunction.runtime` key.  
+It is not necessary if you wish to deploy containers only.
 
 #### Runtimes
 
@@ -159,7 +164,6 @@ Available runtimes are:
 - `node8` and `node10` for JavaScript
 - `python` (2.7) and `python3` (3.7) for Python
 - `golang`
-
 
 #### Functions Handler
 

--- a/examples/multiple/handler.js
+++ b/examples/multiple/handler.js
@@ -1,0 +1,12 @@
+module.exports.handle = (event, context, callback) => {
+  const result = {
+    message: 'Hello from Serverless Framework and Scaleway Functions :D',
+  };
+  const response = {
+    statusCode: 200,
+    body: JSON.stringify(result),
+  };
+
+  // either return cb(undefined, response) or return response
+  return response;
+};

--- a/examples/multiple/handler.py
+++ b/examples/multiple/handler.py
@@ -1,0 +1,10 @@
+def handle(event, context):
+    """handle a request to the function
+    Args:
+        event (dict): request params
+        context (dict): function call metadata
+    """
+
+    return {
+        "message": "Hello From Python3 runtime on Serverless Framework and Scaleway Functions"
+    }

--- a/examples/multiple/package.json
+++ b/examples/multiple/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "multiple-scaleway-starter",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {},
+  "devDependencies": {
+    "serverless-scaleway-functions": "^0.1.15"
+  },
+  "description": ""
+}

--- a/examples/multiple/serverless.yml
+++ b/examples/multiple/serverless.yml
@@ -1,0 +1,33 @@
+service:
+  name: scaleway-node10
+
+provider:
+  name: scaleway
+  runtime: node10
+  # Global Environment variables - used in every functions
+  env:
+    test: test
+  # the path to the credentials file needs to be absolute
+  scwToken: <scw-token>
+  scwOrganization: <scw-organization-id>
+
+plugins:
+  - serverless-scaleway-functions
+
+package:
+  exclude:
+    - .gitignore
+    - .git/**
+
+functions:
+  nodefunc:
+    handler: handler.handle
+    # Local environment variables - used only in given function
+    env:
+      local: local
+  pythonfunc:
+    runtime: python3  # Here we add a specific runtime for the function
+    handler: handler.handle
+    # Local environment variables - used only in given function
+    env:
+      local: local

--- a/examples/nodejs10/serverless.yml
+++ b/examples/nodejs10/serverless.yml
@@ -3,13 +3,13 @@ service:
 
 provider:
   name: scaleway
-  runtime: node10
+  runtime: python3
   # Global Environment variables - used in every functions
   env:
     test: test
   # the path to the credentials file needs to be absolute
-  scwToken: <scw-token>
-  scwOrganization: <scw-organization-id>
+  scwToken: 216c1f65-730b-4488-8f80-99118725da18
+  scwOrganization: 03dca599-b4cf-48db-89a4-05faad6201e4
 
 plugins:
   - serverless-scaleway-functions
@@ -21,6 +21,7 @@ package:
 
 functions:
   first:
+    runtime: node10
     handler: handler.handle
     # Local environment variables - used only in given function
     env:

--- a/examples/nodejs10/serverless.yml
+++ b/examples/nodejs10/serverless.yml
@@ -3,13 +3,13 @@ service:
 
 provider:
   name: scaleway
-  runtime: python3
+  runtime: node10
   # Global Environment variables - used in every functions
   env:
     test: test
   # the path to the credentials file needs to be absolute
-  scwToken: <your-token>
-  scwOrganization: <your-org-id>
+  scwToken: <scw-token>
+  scwOrganization: <scw-organization-id>
 
 plugins:
   - serverless-scaleway-functions
@@ -21,7 +21,6 @@ package:
 
 functions:
   first:
-    runtime: node10
     handler: handler.handle
     # Local environment variables - used only in given function
     env:

--- a/examples/nodejs10/serverless.yml
+++ b/examples/nodejs10/serverless.yml
@@ -8,8 +8,8 @@ provider:
   env:
     test: test
   # the path to the credentials file needs to be absolute
-  scwToken: 216c1f65-730b-4488-8f80-99118725da18
-  scwOrganization: 03dca599-b4cf-48db-89a4-05faad6201e4
+  scwToken: <your-token>
+  scwOrganization: <your-org-id>
 
 plugins:
   - serverless-scaleway-functions

--- a/shared/validate.js
+++ b/shared/validate.js
@@ -92,10 +92,10 @@ module.exports = {
       functionNames.forEach((functionName) => {
 
         const func = functions[functionName];
-        const extensions = RUNTIMES_EXTENSIONS[func.runtime];
         
         // Check that function's runtime is authorized if existing
         if (func.runtime && func.runtime !== 'golang'){
+          const extensions = RUNTIMES_EXTENSIONS[func.runtime];
           if (!extensions) {
             const availableRuntimesMessage = Object.keys(RUNTIMES_EXTENSIONS).join(', ');
             functionErrors.push(`Runtime ${this.runtime} is not supported. Function runtime must be one of the following: ${availableRuntimesMessage}`);

--- a/shared/validate.js
+++ b/shared/validate.js
@@ -82,7 +82,7 @@ module.exports = {
     if (functions && Object.keys(functions).length !== 0) {
       functionNames = Object.keys(functions);
 
-      // Check that runtime is authorized
+      // Check that default runtime is authorized
       const extensions = RUNTIMES_EXTENSIONS[this.runtime];
       if (!extensions) {
         const availableRuntimesMessage = Object.keys(RUNTIMES_EXTENSIONS).join(', ');
@@ -90,9 +90,18 @@ module.exports = {
       }
 
       functionNames.forEach((functionName) => {
+
         const func = functions[functionName];
-        if (this.runtime === 'golang') { // Golang runtime does not work like other runtimes, we should ignore validation for it
-          return;
+        const extensions = RUNTIMES_EXTENSIONS[func.runtime];
+        
+        // Check that function's runtime is authorized if existing
+        if (func.runtime && func.runtime !== 'golang'){
+          if (!extensions) {
+            const availableRuntimesMessage = Object.keys(RUNTIMES_EXTENSIONS).join(', ');
+            functionErrors.push(`Runtime ${this.runtime} is not supported. Function runtime must be one of the following: ${availableRuntimesMessage}`);
+          }
+        } else if (func.runtime === 'golang' || this.runtime === 'golang') {
+          return; // Golang runtime does not work like other runtimes, we should ignore validation for it
         }
 
         // Check if function handler exists

--- a/shared/validate.js
+++ b/shared/validate.js
@@ -92,16 +92,18 @@ module.exports = {
       functionNames.forEach((functionName) => {
 
         const func = functions[functionName];
-        
+
+        if (func.runtime === 'golang' || (!func.runtime && this.runtime === 'golang')) {
+          return; // Golang runtime does not work like other runtimes, we should ignore validation for it
+        }
+
         // Check that function's runtime is authorized if existing
-        if (func.runtime && func.runtime !== 'golang'){
+        if (func.runtime){
           const extensions = RUNTIMES_EXTENSIONS[func.runtime];
           if (!extensions) {
             const availableRuntimesMessage = Object.keys(RUNTIMES_EXTENSIONS).join(', ');
             functionErrors.push(`Runtime ${this.runtime} is not supported. Function runtime must be one of the following: ${availableRuntimesMessage}`);
           }
-        } else if (func.runtime === 'golang' || this.runtime === 'golang') {
-          return; // Golang runtime does not work like other runtimes, we should ignore validation for it
         }
 
         // Check if function handler exists


### PR DESCRIPTION
Example : 
```
service:
  name: scaleway-node10

provider:
  name: scaleway
  runtime: python3       # Default runtime
  env:
    test: test
  scwToken: <token>
  scwOrganization: <token>

plugins:
  - serverless-scaleway-functions

package:
  exclude:
    - .gitignore
    - .git/**

functions:
  first:                # No runtime specified so the default runtime will be used (here: python3)
    handler: handler.handle
    env:
      local: local
  second:
    runtime: node10     # Here you can specify a specific runtime
    handler: handler.handle
    env:
      local: local

```