### PR TITLE
serverless CLI deploy is shown as instant

### DIFF
--- a/deploy/scalewayDeploy.js
+++ b/deploy/scalewayDeploy.js
@@ -71,6 +71,7 @@ class ScalewayDeploy {
         .then(this.createServerlessNamespace)
         .then(chainContainers)
         .then(chainFunctions)
+        .then(this.updateServerlessNamespace)
         .then(this.deployTriggers),
     };
   }


### PR DESCRIPTION
Deploying with serverless CLI looks very fast and shows `Function first has been deployed to...` but in reality the function is still not ready. 

It only happens using serverless CLI.

To reproduce this, ensure you have at least one global environement variable in your serverless config file :

```yaml
service: func
configValidationMode: off
provider:
  name: scaleway
  runtime: python3
  env:
    test: test
```

This fix attend to use a more natural way in deployment workflow without any breaking changes. 