### PR TITLE
List runtimes dynamically from API

### DIFF
--- a/deploy/lib/createFunctions.js
+++ b/deploy/lib/createFunctions.js
@@ -2,8 +2,7 @@
 
 const BbPromise = require('bluebird');
 const secrets = require('../../shared/secrets');
-
-const RUNTIME_STATUS_AVAILABLE = 'available';
+const { RUNTIME_STATUS_AVAILABLE } = require('../../shared/runtimes');
 
 module.exports = {
   createFunctions() {
@@ -30,7 +29,7 @@ module.exports = {
       });
   },
 
-  validateRuntime(func, existingRuntimes) {
+  validateRuntime(func, existingRuntimes, logger) {
     const existingRuntimesGroupedByLanguage = existingRuntimes
       .reduce((r, a) => {
         r[a.language] = r[a.language] || [];
@@ -54,7 +53,7 @@ module.exports = {
         if (runtime.statusMessage !== null && runtime.statusMessage !== undefined && runtime.statusMessage !== '') {
           warnMessage += `: ${runtime.statusMessage}`;
         }
-        console.warn(warnMessage);
+        logger.log(warnMessage);
       }
       return currentRuntime;
     }
@@ -87,7 +86,7 @@ module.exports = {
     };
 
     const availableRuntimes = await this.listRuntimes();
-    params.runtime = this.validateRuntime(func, availableRuntimes);
+    params.runtime = this.validateRuntime(func, availableRuntimes, this.serverless.cli);
 
     this.serverless.cli.log(`Creating function ${func.name}...`);
     return this.createFunction(params)

--- a/shared/api/index.js
+++ b/shared/api/index.js
@@ -7,6 +7,7 @@ const containersApi = require('./containers');
 const triggersApi = require('./triggers');
 const jwtApi = require('./jwt');
 const logsApi = require('./logs');
+const runtimesApi = require('./runtimes');
 
 // Registry
 const RegistryApi = require('./registry');
@@ -33,6 +34,7 @@ class FunctionApi {
       triggersApi,
       jwtApi,
       logsApi,
+      runtimesApi,
     );
   }
 }
@@ -47,6 +49,7 @@ class ContainerApi {
       triggersApi,
       jwtApi,
       logsApi,
+      runtimesApi,
     );
   }
 }

--- a/shared/api/runtimes.js
+++ b/shared/api/runtimes.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const { manageError } = require('./utils');
+
+module.exports = {
+  listRuntimes() {
+    const functionsUrl = `runtimes`;
+    return this.apiManager.get(functionsUrl)
+      .then(response => response.data.runtimes || [])
+      .catch(manageError);
+  },
+};

--- a/shared/runtimes.js
+++ b/shared/runtimes.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const RUNTIME_STATUS_AVAILABLE = 'available';
+
+module.exports = {
+  RUNTIME_STATUS_AVAILABLE,
+};

--- a/tests/functions/functions.test.js
+++ b/tests/functions/functions.test.js
@@ -121,6 +121,11 @@ describe('Service Lifecyle Integration Test', () => {
 });
 
 describe('validateRuntimes', () => {
+  beforeEach(() => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    consoleSpy.mockClear();
+  });
+
   it('should throw an error if runtime does not exist', () => {
     const func = { runtime: 'bash4' };
     const existingRuntimes = [
@@ -130,6 +135,7 @@ describe('validateRuntimes', () => {
     const actual = () => validateRuntime(func, existingRuntimes);
     expect(actual).to.throw(Error);
     expect(actual).to.throw('Runtime "bash4" does not exist, must be one of: node17, go118');
+    jestExpect(console.log).toHaveBeenCalledTimes(0);
   });
 
   it('should throw an error if no runtime exists', () => {
@@ -138,6 +144,7 @@ describe('validateRuntimes', () => {
     const actual = () => validateRuntime(func, existingRuntimes);
     expect(actual).to.throw(Error);
     expect(actual).to.throw('Runtime "node17" does not exist: cannot list runtimes');
+    jestExpect(console.log).toHaveBeenCalledTimes(0);
   });
 
   it('should work if runtime is available', () => {
@@ -149,6 +156,7 @@ describe('validateRuntimes', () => {
     const actual = validateRuntime(func, existingRuntimes);
     const expected = 'node17';
     expect(actual).to.equal(expected);
+    jestExpect(console.log).toHaveBeenCalledTimes(0);
   });
 
   it('should work and print a message if runtime is not available and no status message', () => {
@@ -159,14 +167,11 @@ describe('validateRuntimes', () => {
       { name: 'bash4', language: 'Bash', status: 'beta' },
     ];
 
-    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
-    consoleSpy.mockClear();
-
-    const actual = validateRuntime(func, existingRuntimes);
+    const actual = validateRuntime(func, existingRuntimes, console);
     const expected = 'bash4';
     expect(actual).to.equal(expected);
-    jestExpect(console.warn).toHaveBeenCalledTimes(1);
-    jestExpect(console.warn).toHaveBeenLastCalledWith('WARNING: Runtime bash4 is in status beta');
+    jestExpect(console.log).toHaveBeenCalledTimes(1);
+    jestExpect(console.log).toHaveBeenLastCalledWith('WARNING: Runtime bash4 is in status beta');
   });
 
   it('should work and print a message if runtime is not available and there is a status message', () => {
@@ -177,14 +182,11 @@ describe('validateRuntimes', () => {
       { name: 'bash4', language: 'Bash', status: 'beta', status_message: 'use with caution' },
     ];
 
-    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
-    consoleSpy.mockClear();
-
-    const actual = validateRuntime(func, existingRuntimes);
+    const actual = validateRuntime(func, existingRuntimes, console);
     const expected = 'bash4';
     expect(actual).to.equal(expected);
-    jestExpect(console.warn).toHaveBeenCalledTimes(1);
-    jestExpect(console.warn).toHaveBeenLastCalledWith(
+    jestExpect(console.log).toHaveBeenCalledTimes(1);
+    jestExpect(console.log).toHaveBeenLastCalledWith(
       'WARNING: Runtime bash4 is in status beta: use with caution',
     );
   });

--- a/tests/functions/functions.test.js
+++ b/tests/functions/functions.test.js
@@ -4,11 +4,13 @@ const path = require('path');
 const fs = require('fs');
 const axios = require('axios');
 const { expect } = require('chai');
+const { expect: jestExpect } = require('@jest/globals');
 const { execSync } = require('../utils/child-process');
 const { getTmpDirPath, replaceTextInFile } = require('../utils/fs');
 const { getServiceName, sleep } = require('../utils/misc');
 const { FunctionApi, RegistryApi } = require('../../shared/api');
 const { FUNCTIONS_API_URL, REGISTRY_API_URL } = require('../../shared/constants');
+const { validateRuntime } = require('../../deploy/lib/createFunctions');
 
 const serverlessExec = path.join('serverless');
 
@@ -115,5 +117,75 @@ describe('Service Lifecyle Integration Test', () => {
     } catch (err) {
       // if not try catch, test would fail
     }
+  });
+});
+
+describe('validateRuntimes', () => {
+  it('should throw an error if runtime does not exist', () => {
+    const func = { runtime: 'bash4' };
+    const existingRuntimes = [
+      { name: 'node17', language: 'Node' },
+      { name: 'go118', language: 'Go' },
+    ];
+    const actual = () => validateRuntime(func, existingRuntimes);
+    expect(actual).to.throw(Error);
+    expect(actual).to.throw('Runtime "bash4" does not exist, must be one of: node17, go118');
+  });
+
+  it('should throw an error if no runtime exists', () => {
+    const func = { runtime: 'node17' };
+    const existingRuntimes = [];
+    const actual = () => validateRuntime(func, existingRuntimes);
+    expect(actual).to.throw(Error);
+    expect(actual).to.throw('Runtime "node17" does not exist: cannot list runtimes');
+  });
+
+  it('should work if runtime is available', () => {
+    const func = { runtime: 'node17' };
+    const existingRuntimes = [
+      { name: 'node17', language: 'Node', status: 'available' },
+      { name: 'go118', language: 'Go', status: 'available' },
+    ];
+    const actual = validateRuntime(func, existingRuntimes);
+    const expected = 'node17';
+    expect(actual).to.equal(expected);
+  });
+
+  it('should work and print a message if runtime is not available and no status message', () => {
+    const func = { runtime: 'bash4' };
+    const existingRuntimes = [
+      { name: 'node17', language: 'Node', status: 'available' },
+      { name: 'go118', language: 'Go', status: 'available' },
+      { name: 'bash4', language: 'Bash', status: 'beta' },
+    ];
+
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+    consoleSpy.mockClear();
+
+    const actual = validateRuntime(func, existingRuntimes);
+    const expected = 'bash4';
+    expect(actual).to.equal(expected);
+    jestExpect(console.warn).toHaveBeenCalledTimes(1);
+    jestExpect(console.warn).toHaveBeenLastCalledWith('WARNING: Runtime bash4 is in status beta');
+  });
+
+  it('should work and print a message if runtime is not available and there is a status message', () => {
+    const func = { runtime: 'bash4' };
+    const existingRuntimes = [
+      { name: 'node17', language: 'Node', status: 'available' },
+      { name: 'go118', language: 'Go', status: 'available' },
+      { name: 'bash4', language: 'Bash', status: 'beta', status_message: 'use with caution' },
+    ];
+
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+    consoleSpy.mockClear();
+
+    const actual = validateRuntime(func, existingRuntimes);
+    const expected = 'bash4';
+    expect(actual).to.equal(expected);
+    jestExpect(console.warn).toHaveBeenCalledTimes(1);
+    jestExpect(console.warn).toHaveBeenLastCalledWith(
+      'WARNING: Runtime bash4 is in status beta: use with caution',
+    );
   });
 });


### PR DESCRIPTION
It is possible to list runtimes dynamically from API : https://developers.scaleway.com/en/products/functions/api/#get-f7de6a

This PR aims to retrieve those runtimes when creating a function, and validating the runtime. Also, if the runtime have a status different than `available`, a warning is printed with `status_message` field.