### PR TITLE
A handler must return a promise

### DIFF
--- a/examples/nodejs-schedule/handler.js
+++ b/examples/nodejs-schedule/handler.js
@@ -1,4 +1,4 @@
-module.exports.handle = (event, context, callback) => {
+module.exports.handle = async (event, context, callback) => {
   const result = {
     message: 'Hello from Serverless Framework and Scaleway Functions :D',
   };


### PR DESCRIPTION
when not sending result via callback