### PR TITLE
Documentation and example for Go >= 1.17

### DIFF
--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -2,12 +2,12 @@
 
 ## Requirements
 
-- your code must be a valid Go module: a `go.mod` file is expected at the root
+- your code must be a valid Go module: a `go.mod` file is expected in the root directory
 - your handler function should be in a file at the root of your module
-- your handler must be exported: `Handle` is correct, `handle` is not
+- your handler must be exported, example: `Handle` is correct, `handle` is not because it is not exported
 - `main` package is reserved: you must not have any package named `main` in your module
 
-Example of a right structure:
+Suggested code layout:
 
 ```
 .
@@ -21,3 +21,5 @@ Example of a right structure:
 ## Run
 
 If your code depends on private dependencies, you will need to run `go mod vendor` before deploying your function.
+
+See [Official Go Vendoring reference](https://go.dev/ref/mod#go-mod-vendor).

--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -1,38 +1,23 @@
-# Golang Runtime with Dep as Dependencies Manager
+# Go Runtime (>= 1.17)
 
 ## Requirements
 
-Every handler must be in its own package, identified by `package main`, and exporting a main function with the following `lambda.Start` statement:
-```go
-// Must Always be package main
-package main
+- your code must be a valid Go module: a `go.mod` file is expected at the root
+- your handler function should be in a file at the root of your module
+- your handler must be exported: `Handle` is correct, `handle` is not
+- `main` package is reserved: you must not have any package named `main` in your module
 
-import (
-	"encoding/json"
-	"http"
-	
-  // Import both of these packages
-	"github.com/scaleway/scaleway-functions-go/events"
-	"github.com/scaleway/scaleway-functions-go/lambda"
-)
+Example of a right structure:
 
-// Handler - Your handler function, uses APIGatewayProxy event type as your function will always get HTTP formatted events, even for CRON
-func Handler(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	return events.APIGatewayProxyResponse{
-		Body:       "Your response",
-		StatusCode: http.StatusOK,
-	}, nil
-}
-
-// Main function is mandatory -> Must call lambda.Start(yourHandler) otherwhise your handler will not be called properly.
-func main() {
-	lambda.Start(Handler)
-}
+```
+.
+├── go.mod        # your go.mod defines your module
+├── go.sum        # not always necessary 
+├── myfunc.go     # your handler method (exported) must be defined here
+└── subpackage    # you can have subpackages
+    └── hello.go  # with files inside
 ```
 
 ## Run
 
-Additonnaly you may run `go mod vendor`.
-
-We are building `golang` binaries inside our APIs, although we need you to package all your code with `vendors` (dependencies), so a `go build` command would work properly without prior installations on our side.
-
+If your code depends on private dependencies, you will need to run `go mod vendor` before deploying your function.

--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -5,6 +5,7 @@
 - your code must be a valid Go module: a `go.mod` file is expected in the root directory
 - your handler function should be in a file at the root of your module
 - your handler must be exported, example: `Handle` is correct, `handle` is not because it is not exported
+- your handler must have the following signature: `func Handle(w http.ResponseWriter, r *http.Request)`
 - `main` package is reserved: you must not have any package named `main` in your module
 
 Suggested code layout:

--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -19,6 +19,22 @@ Suggested code layout:
     └── hello.go  # with files inside
 ```
 
+## Handler name
+
+The `handler name` is the name of your handler function (example: `Handle`).
+
+If your code is in a subfolder, like this:
+
+```
+.
+└── subfolder
+   ├── go.mod
+   ├── go.sum
+   └── myfunc.go # Handle function in that file
+```
+
+The `handler name` must be composed of the folder name and the handler function name, separated by `/`. For the example above, `subfolder/Handle` is the right `handler name`.
+
 ## Run
 
 If your code depends on private dependencies, you will need to run `go mod vendor` before deploying your function.

--- a/examples/go/go.mod
+++ b/examples/go/go.mod
@@ -1,5 +1,3 @@
 module myhandler
 
 go 1.18
-
-require github.com/scaleway/scaleway-functions-go v0.0.0-20211103103919-280251df088b

--- a/examples/go/handler.go
+++ b/examples/go/handler.go
@@ -1,15 +1,13 @@
-package main
+package myfunc
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
-
-	"github.com/scaleway/scaleway-functions-go/events"
-	"github.com/scaleway/scaleway-functions-go/lambda"
 )
 
-// Handler - Handle event
-func Handler(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+// Handle - Handle event
+func Handle(w http.ResponseWriter, r *http.Request) {
 	response := map[string]interface{}{
 		"message": "We're all good",
 		"healthy": true,
@@ -18,15 +16,10 @@ func Handler(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse,
 
 	responseB, err := json.Marshal(response)
 	if err != nil {
-		return events.APIGatewayProxyResponse{}, err
+		w.WriteHeader(http.StatusInternalServerError)
+		return
 	}
 
-	return events.APIGatewayProxyResponse{
-		Body:       string(responseB),
-		StatusCode: http.StatusOK,
-	}, nil
-}
-
-func main() {
-	lambda.Start(Handler)
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprint(w, string(responseB))
 }

--- a/examples/go/mypackage/go.mod
+++ b/examples/go/mypackage/go.mod
@@ -1,5 +1,3 @@
 module mypackage
 
 go 1.18
-
-require github.com/scaleway/scaleway-functions-go v0.0.0-20211103103919-280251df088b

--- a/examples/go/mypackage/handler.go
+++ b/examples/go/mypackage/handler.go
@@ -1,30 +1,25 @@
-package main
+package myfunc
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
-
-	"github.com/scaleway/scaleway-functions-go/events"
-	"github.com/scaleway/scaleway-functions-go/lambda"
 )
 
-// Handler - Handle event
-func Handler(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+// Handle - Handle event
+func Handle(w http.ResponseWriter, r *http.Request) {
 	response := map[string]interface{}{
-		"message": "My Custom Package",
+		"message": "We're all good",
+		"healthy": true,
+		"number":  4,
 	}
 
 	responseB, err := json.Marshal(response)
 	if err != nil {
-		return events.APIGatewayProxyResponse{}, err
+		w.WriteHeader(http.StatusInternalServerError)
+		return
 	}
 
-	return events.APIGatewayProxyResponse{
-		Body:       string(responseB),
-		StatusCode: http.StatusOK,
-	}, nil
-}
-
-func main() {
-	lambda.Start(Handler)
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprint(w, string(responseB))
 }

--- a/examples/go/package.json
+++ b/examples/go/package.json
@@ -9,7 +9,7 @@
   "license": "ISC",
   "dependencies": {},
   "devDependencies": {
-    "serverless-scaleway-functions": "^0.3.1"
+    "serverless-scaleway-functions": "^0.3.2"
   },
   "description": ""
 }

--- a/examples/go113/README.md
+++ b/examples/go113/README.md
@@ -1,0 +1,37 @@
+# Golang Runtime (< 1.17)
+
+## Requirements
+
+Every handler must be in its own package, identified by `package main`, and exporting a main function with the following `lambda.Start` statement:
+```go
+// Must Always be package main
+package main
+
+import (
+	"encoding/json"
+	"http"
+	
+  // Import both of these packages
+	"github.com/scaleway/scaleway-functions-go/events"
+	"github.com/scaleway/scaleway-functions-go/lambda"
+)
+
+// Handler - Your handler function, uses APIGatewayProxy event type as your function will always get HTTP formatted events, even for CRON
+func Handler(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	return events.APIGatewayProxyResponse{
+		Body:       "Your response",
+		StatusCode: http.StatusOK,
+	}, nil
+}
+
+// Main function is mandatory -> Must call lambda.Start(yourHandler) otherwhise your handler will not be called properly.
+func main() {
+	lambda.Start(Handler)
+}
+```
+
+## Run
+
+Additonnaly you may run `go mod vendor`.
+
+We are building `golang` binaries inside our APIs, although we need you to package all your code with `vendors` (dependencies), so a `go build` command would work properly without prior installations on our side.

--- a/examples/go113/go.mod
+++ b/examples/go113/go.mod
@@ -1,0 +1,5 @@
+module myhandler
+
+go 1.13
+
+require github.com/scaleway/scaleway-functions-go v0.0.0-20211103103919-280251df088b

--- a/examples/go113/go.sum
+++ b/examples/go113/go.sum
@@ -1,0 +1,2 @@
+github.com/scaleway/scaleway-functions-go v0.0.0-20211103103919-280251df088b h1:eka9SeAYikcsQfbZGg3vEmea9+1AngpPkXUrkv7ByOc=
+github.com/scaleway/scaleway-functions-go v0.0.0-20211103103919-280251df088b/go.mod h1:bpwyJakDwy3vzlVI6EydCG3uK50TrH46S65+bfTRAfM=

--- a/examples/go113/handler.go
+++ b/examples/go113/handler.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/scaleway/scaleway-functions-go/events"
+	"github.com/scaleway/scaleway-functions-go/lambda"
+)
+
+// Handler - Handle event
+func Handler(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	response := map[string]interface{}{
+		"message": "We're all good",
+		"healthy": true,
+		"number":  4,
+	}
+
+	responseB, err := json.Marshal(response)
+	if err != nil {
+		return events.APIGatewayProxyResponse{}, err
+	}
+
+	return events.APIGatewayProxyResponse{
+		Body:       string(responseB),
+		StatusCode: http.StatusOK,
+	}, nil
+}
+
+func main() {
+	lambda.Start(Handler)
+}

--- a/examples/go113/mypackage/go.mod
+++ b/examples/go113/mypackage/go.mod
@@ -1,0 +1,5 @@
+module mypackage
+
+go 1.13
+
+require github.com/scaleway/scaleway-functions-go v0.0.0-20211103103919-280251df088b

--- a/examples/go113/mypackage/go.sum
+++ b/examples/go113/mypackage/go.sum
@@ -1,0 +1,2 @@
+github.com/scaleway/scaleway-functions-go v0.0.0-20211103103919-280251df088b h1:eka9SeAYikcsQfbZGg3vEmea9+1AngpPkXUrkv7ByOc=
+github.com/scaleway/scaleway-functions-go v0.0.0-20211103103919-280251df088b/go.mod h1:bpwyJakDwy3vzlVI6EydCG3uK50TrH46S65+bfTRAfM=

--- a/examples/go113/mypackage/handler.go
+++ b/examples/go113/mypackage/handler.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/scaleway/scaleway-functions-go/events"
+	"github.com/scaleway/scaleway-functions-go/lambda"
+)
+
+// Handler - Handle event
+func Handler(req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	response := map[string]interface{}{
+		"message": "My Custom Package",
+	}
+
+	responseB, err := json.Marshal(response)
+	if err != nil {
+		return events.APIGatewayProxyResponse{}, err
+	}
+
+	return events.APIGatewayProxyResponse{
+		Body:       string(responseB),
+		StatusCode: http.StatusOK,
+	}, nil
+}
+
+func main() {
+	lambda.Start(Handler)
+}

--- a/examples/go113/package.json
+++ b/examples/go113/package.json
@@ -9,7 +9,7 @@
   "license": "ISC",
   "dependencies": {},
   "devDependencies": {
-    "serverless-scaleway-functions": "^0.3.1"
+    "serverless-scaleway-functions": "^0.3.2"
   },
   "description": ""
 }

--- a/examples/go113/package.json
+++ b/examples/go113/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "golang-scaleway-starter",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {},
+  "devDependencies": {
+    "serverless-scaleway-functions": "^0.3.1"
+  },
+  "description": ""
+}

--- a/examples/go113/serverless.yml
+++ b/examples/go113/serverless.yml
@@ -2,7 +2,7 @@ service: scaleway-golang
 configValidationMode: off
 provider:
   name: scaleway
-  runtime: go118 # Available go runtimes are listed in documentation
+  runtime: go113 # Available go runtimes are listed in documentation
   # Global Environment variables - used in every functions
   env:
     test: test
@@ -23,13 +23,12 @@ package:
 
 functions:
   first:
-    # handler is just the name of the exported handler function
-    handler: Handle
+    # If handler is at the root of your serverless project
+    handler: "."
     # Local environment variables - used only in given function
     env:
       local: local
 
-  mymodule:
-    # if your handler is defined at the root of a file on the module `mypackage`
-    # `mypackage` folder must be a valid Go module (with a go.mod)
-    handler: "mypackage/Handle"
+  mypackage:
+    # if your handler is in a custom package
+    handler: mypackage


### PR DESCRIPTION
- move the golang and go113 example in go113 folder
- create a folder go (for Go >= 1.17) with an example