### PR TITLE
add more details to eol/eos runtimes

### DIFF
--- a/deploy/lib/createFunctions.js
+++ b/deploy/lib/createFunctions.js
@@ -167,7 +167,6 @@ Runtime lifecycle doc : https://www.scaleway.com/en/docs/compute/functions/refer
 
           `);
           return currentRuntime;
-          break;
 
         case RUNTIME_STATUS_EOS:
           logger.log(`Runtime ${runtime.name} is in End Of Support. It is no longer possible to create a new function with this runtime; however, functions that already use it can still be updated.
@@ -178,7 +177,6 @@ Runtime lifecycle doc : https://www.scaleway.com/en/docs/compute/functions/refer
            `);
 
           return currentRuntime;
-          break;
 
         default:
           let warnMessage = `WARNING: Runtime ${currentRuntime} is in status ${runtime.status}`;
@@ -190,7 +188,8 @@ Runtime lifecycle doc : https://www.scaleway.com/en/docs/compute/functions/refer
             warnMessage += `: ${runtime.statusMessage}`;
           }
           logger.log(warnMessage);
-          break;
+
+          return currentRuntime;
       }
     }
 

--- a/deploy/lib/createFunctions.js
+++ b/deploy/lib/createFunctions.js
@@ -160,11 +160,24 @@ module.exports = {
           return currentRuntime;
 
         case RUNTIME_STATUS_EOL:
-          logger.log(`Runtime ${runtime.name} is in End Of Life. Functions that use this runtime will still be working, but it is no more possible to update them. Note : ${runtime.statusMessage}`);
+          logger.log(`Runtime ${runtime.name} is in End Of Life. Functions that use this runtime will still be working, but it is no more possible to update them.
+Note : ${runtime.statusMessage}
+
+Runtime lifecycle doc : https://www.scaleway.com/en/docs/compute/functions/reference-content/functions-lifecycle/#available-runtimes
+
+          `);
+          return currentRuntime;
           break;
 
         case RUNTIME_STATUS_EOS:
-          logger.log(`Runtime ${runtime.name} is in End Of Support. It is no longer possible to create a new function with this runtime; however, functions that already use it can still be updated. Note : ${runtime.statusMessage}`);
+          logger.log(`Runtime ${runtime.name} is in End Of Support. It is no longer possible to create a new function with this runtime; however, functions that already use it can still be updated.
+Note : ${runtime.statusMessage}
+
+Runtime lifecycle doc : https://www.scaleway.com/en/docs/compute/functions/reference-content/functions-lifecycle/#available-runtimes
+
+           `);
+
+          return currentRuntime;
           break;
 
         default:

--- a/shared/runtimes.js
+++ b/shared/runtimes.js
@@ -2,7 +2,7 @@
 
 const RUNTIME_STATUS_AVAILABLE = 'available';
 const RUNTIME_STATUS_EOS = 'end_of_support';
-const RUNTIME_STATUS_EOL = 'end_of_live';
+const RUNTIME_STATUS_EOL = 'end_of_life';
 
 module.exports = {
   RUNTIME_STATUS_AVAILABLE,

--- a/shared/runtimes.js
+++ b/shared/runtimes.js
@@ -1,7 +1,11 @@
 'use strict'
 
 const RUNTIME_STATUS_AVAILABLE = 'available';
+const RUNTIME_STATUS_EOS = 'end_of_support';
+const RUNTIME_STATUS_EOL = 'end_of_live';
 
 module.exports = {
   RUNTIME_STATUS_AVAILABLE,
+  RUNTIME_STATUS_EOS,
+  RUNTIME_STATUS_EOL,
 };


### PR DESCRIPTION
Added some details to warn about EOL and EOS

Result in shell :  

```
Using credentials from system environment
Runtime undefined is in End Of Support. It is no longer possible to create a new function with this runtime; however, functions that already use it can still be updated.
Note : Node 17 reached end of security support 1st June 2022, please upgrade to Node 16 or Node 18

Runtime lifecycle doc : https://www.scaleway.com/en/docs/compute/functions/reference-content/functions-lifecycle/#available-runtimes

           
Creating function first...
Environment: darwin, node 16.14.0, framework 3.19.0, plugin 6.2.2, SDK 4.3.2
Docs:        docs.serverless.com
Support:     forum.serverless.com
Bugs:        github.com/serverless/serverless/issues

Error:
Error: message : Node 17 reached end of security support 1st June 2022, please upgrade to Node 16 or Node 18, error : rpc error: code = InvalidArgument desc = runtime reached end of support, could not create new functions

```