### PR TITLE
ensure registry image priority is serverless framework

### DIFF
--- a/deploy/lib/createContainers.js
+++ b/deploy/lib/createContainers.js
@@ -114,6 +114,7 @@ module.exports = {
       memory_limit: container.memoryLimit,
       min_scale: container.minScale,
       max_scale: container.maxScale,
+      registry_image: `${this.namespace.registry_endpoint}/${container.name}:latest`,
       max_concurrency: container.maxConcurrency,
       timeout: container.timeout,
       privacy: container.privacy,
@@ -126,6 +127,6 @@ module.exports = {
     this.applyDomainsContainer(foundContainer.id, container.custom_domains);
 
     return this.updateContainer(foundContainer.id, params)
-      .then(response => Object.assign(response, { directory: container.directory }));
+      .then((response) => Object.assign(response, { directory: container.directory }));
   },
 };

--- a/deploy/lib/createContainers.js
+++ b/deploy/lib/createContainers.js
@@ -127,6 +127,6 @@ module.exports = {
     this.applyDomainsContainer(foundContainer.id, container.custom_domains);
 
     return this.updateContainer(foundContainer.id, params)
-      .then((response) => Object.assign(response, { directory: container.directory }));
+      .then(response => Object.assign(response, { directory: container.directory }));
   },
 };

--- a/tests/containers/containers_private_registry.test.js
+++ b/tests/containers/containers_private_registry.test.js
@@ -91,7 +91,7 @@ describe('Build and deploy on container with a base image private', () => {
     // TODO query function status instead of having an arbitrary sleep
     await sleep(30000);
 
-    let output = execCaptureOutput(serverlessExec, ['invoke', '--function', containerName]);
+    const output = execCaptureOutput(serverlessExec, ['invoke', '--function', containerName]);
     expect(output).to.be.equal('{"message":"Hello, World from Scaleway Container !"}');
   });
 


### PR DESCRIPTION
When assigning to a container an image from an other source (for example the console) it will not be updated on `serverless deploy` command

So I added in updating parameter the registry image to ensure it's the one pushed by serverless framework.

Closes #111 