### PR TITLE
fix: js-yaml is actually a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "axios": "^0.27.2",
         "bluebird": "^3.7.2",
         "dockerode": "^3.3.4",
+        "js-yaml": "^4.1.0",
         "tar-fs": "^2.1.1"
       },
       "devDependencies": {
@@ -24,7 +25,6 @@
         "eslint-plugin-import": "^2.26.0",
         "fs-extra": "^10.1.0",
         "jest": "^29.0.3",
-        "js-yaml": "^4.1.0",
         "rewire": "^6.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "axios": "^0.27.2",
     "bluebird": "^3.7.2",
     "dockerode": "^3.3.4",
+    "js-yaml": "^4.1.0",
     "tar-fs": "^2.1.1"
   },
   "devDependencies": {
@@ -61,7 +62,6 @@
     "eslint-plugin-import": "^2.26.0",
     "fs-extra": "^10.1.0",
     "jest": "^29.0.3",
-    "js-yaml": "^4.1.0",
     "rewire": "^6.0.0"
   }
 }


### PR DESCRIPTION
Move `js-yaml` from `devDependencies` to `dependencies`, as this is actually used in the library code and this triggers some package managers such as yarn v2+:

```
❯ yarn serverless deploy
Environment: darwin, node 18.10.0, framework 3.23.0 (local), plugin 6.2.2, SDK 4.3.2
Docs:        docs.serverless.com
Support:     forum.serverless.com
Bugs:        github.com/serverless/serverless/issues

Error:
Error: serverless-scaleway-functions tried to access js-yaml, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
```