### PR TITLE
set timeout in seconds in container examples

### DIFF
--- a/examples/container-schedule/serverless.yml
+++ b/examples/container-schedule/serverless.yml
@@ -30,7 +30,7 @@ custom:
       # memoryLimit: 256
       # maxScale: 2
       # maxConcurrency: 50
-      # timeout: 20000
+      # timeout: "20s"
       # httpOption: redirected
       # Local environment variables - used only in given function
       env:

--- a/examples/container/serverless.yml
+++ b/examples/container/serverless.yml
@@ -24,7 +24,7 @@ custom:
       # memoryLimit: 256
       # maxScale: 2
       # maxConcurrency: 50
-      # timeout: 20000
+      # timeout: "20s"
       # port: 8080
       # httpOption: redirected
       # Local environment variables - used only in given function


### PR DESCRIPTION
Hello!

I got the following error when using the container example with the `timeout` value set:
```
→ sls deploy                                                                                                                                                                                         
...
Environment: linux, node 19.7.0, framework 3.16.0, plugin 6.2.2, SDK 4.3.2
Docs:        docs.serverless.com
Support:     forum.serverless.com
Bugs:        github.com/serverless/serverless/issue

Error:
Error: proto: syntax error (line 1:183): unexpected token 20000
    at manageError (<path>/node_modules/serverless-scaleway-functions/shared/api/utils.js:23:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 0)
```

Searching a bit, I found that the timeout value should be provided in seconds. So here is a small PR to update examples containing the `timeout` field with a valid value.