### PR TITLE
Fix error type serverless invoke

### DIFF
--- a/invoke/scalewayInvoke.js
+++ b/invoke/scalewayInvoke.js
@@ -1,5 +1,6 @@
 const BbPromise = require('bluebird');
 const axios = require('axios');
+const { EOL } = require('os');
 
 const scalewayApi = require('../shared/api/endpoint');
 const setUpDeployment = require('../shared/setUpDeployment');
@@ -62,7 +63,7 @@ class ScalewayInvoke {
         process.stdout.write(JSON.stringify(res.data));
       }).
       catch(error => {
-        process.stderr.write(error.toString());
+        process.stderr.write(error.toString() + EOL);
       });
     }
 

--- a/invoke/scalewayInvoke.js
+++ b/invoke/scalewayInvoke.js
@@ -62,7 +62,7 @@ class ScalewayInvoke {
         process.stdout.write(JSON.stringify(res.data));
       }).
       catch(error => {
-        process.stderr.write(error);
+        process.stderr.write(error.toString());
       });
     }
 


### PR DESCRIPTION
Mentionned in https://github.com/scaleway/serverless-scaleway-functions/issues/147

The error returned by function calls on `serverless invoke` command was not readable because of the wrong type.

After toString conversion :  
```
 serverless invoke --function testfunc
[...]
AxiosError: Request failed with status code 403%
```