### PR TITLE
Update README.md to clarify that users need to login to Serverless CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is the [Scaleway Functions](https://www.scaleway.com/en/serverless-function
 - You have generated an [API key](https://www.scaleway.com/en/docs/console/my-project/how-to/generate-api-key/).
 - You have set up the [Scaleway CLI](https://www.scaleway.com/en/cli/).
 - You have installed `node.js` on your local computer
-- You have installed the [Serverless](https://serverless.com) CLI on your local computer (to do so, run `npm install serverless -g` in a terminal).
+- You have installed the [Serverless](https://serverless.com) CLI on your local computer (to do so, run `npm install serverless -g` in a terminal) and logged in to your Serverless account on the CLI (to do so, run `serverless login` and follow instructions).
 
 ## Quickstart
 


### PR DESCRIPTION
## Summary

**_What's changed?_**

Updated documentation for setting up

**_Why do we need this?_**

It wasnt clear that users need to also log in to a separate Serverless account on the CLI. I just spent some time trying to debug this as I was getting an "authentication is denied" error and thought it was a Scaleway issue.

**_How have you tested it?_**

I have logged in which resolved my issue

## Checklist

- [ ] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [x] I have updated the relevant documentation

## Details
