### PR TITLE
fix: deploy container with registry image

### DIFF
--- a/deploy/lib/buildAndPushContainers.js
+++ b/deploy/lib/buildAndPushContainers.js
@@ -68,13 +68,16 @@ module.exports = {
     const containerNames = Object.keys(this.containers);
     const promises = containerNames.map((containerName) => {
       const container = this.containers[containerName];
+      if (container['directory'] == undefined) {
+        return
+      }
       const tarStream = tar.pack(`./${container.directory}`);
       const imageName = `${this.namespace.registry_endpoint}/${container.name}:latest`;
 
       this.serverless.cli.log(
         `Building and pushing container ${container.name} to: ${imageName} ...`
       );
-
+      
       return new Promise(async (resolve, reject) => {
         const buildStream = await docker.buildImage(tarStream, {
           t: imageName,

--- a/deploy/lib/buildAndPushContainers.js
+++ b/deploy/lib/buildAndPushContainers.js
@@ -68,7 +68,7 @@ module.exports = {
     const containerNames = Object.keys(this.containers);
     const promises = containerNames.map((containerName) => {
       const container = this.containers[containerName];
-      if (container["directory"] == undefined) {
+      if (container["directory"] === undefined) {
         return;
       }
       const tarStream = tar.pack(`./${container.directory}`);

--- a/deploy/lib/buildAndPushContainers.js
+++ b/deploy/lib/buildAndPushContainers.js
@@ -68,8 +68,8 @@ module.exports = {
     const containerNames = Object.keys(this.containers);
     const promises = containerNames.map((containerName) => {
       const container = this.containers[containerName];
-      if (container['directory'] == undefined) {
-        return
+      if (container["directory"] == undefined) {
+        return;
       }
       const tarStream = tar.pack(`./${container.directory}`);
       const imageName = `${this.namespace.registry_endpoint}/${container.name}:latest`;
@@ -77,7 +77,7 @@ module.exports = {
       this.serverless.cli.log(
         `Building and pushing container ${container.name} to: ${imageName} ...`
       );
-      
+
       return new Promise(async (resolve, reject) => {
         const buildStream = await docker.buildImage(tarStream, {
           t: imageName,


### PR DESCRIPTION
## Summary

**_What's changed?_**

If container's directory is empty, don't build and push an image. The image registry is used instead to deploy the container.

**_Why do we need this?_**

Fix bug.

**_How have you tested it?_**

Deployed locally two containers: one with directory, the other one only with registry image. It is assumed that a user will never use a directory and a registry image at the same time as stated on the readme guidelines.

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details
