### PR TITLE
Add a deprecation message when running "serverless logs" command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.10
+
+### Changed
+
+- Display a deprecation warning when running `serverless logs` command #212
+
 ## 0.4.9
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -251,6 +251,10 @@ This can be switched off by setting the `singleSource` option to `false`.
 
 ### `serverless logs`
 
+> [!WARNING]
+> This command is deprecated and will be removed on March 12, 2024. Please refer to the documentation (for [functions](https://www.scaleway.com/en/developers/api/serverless-functions/#logs) and [containers](https://www.scaleway.com/en/developers/api/serverless-functions/#logs)) to continue getting your logs.
+> TL;DR: You can still access function and container logs conveniently via the [Cockpit](https://www.scaleway.com/en/docs/observability/cockpit/how-to/access-grafana-and-managed-dashboards/) interface. Dedicated dashboards called "Serverless Functions Logs" and "Serverless Containers Logs" are accessible there.
+
 The `serverless logs` command lets you watch the logs of a specific function or container.
 
 You can fetch the logs of a specific function for with the `--function` option. You must specify the name of your function in the command.

--- a/examples/container-schedule/package.json
+++ b/examples/container-schedule/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {},
   "devDependencies": {
-    "serverless-scaleway-functions": ">=0.4.9"
+    "serverless-scaleway-functions": ">=0.4.10"
   },
   "description": ""
 }

--- a/examples/container/package.json
+++ b/examples/container/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {},
   "devDependencies": {
-    "serverless-scaleway-functions": ">=0.4.9"
+    "serverless-scaleway-functions": ">=0.4.10"
   },
   "description": ""
 }

--- a/examples/go/package.json
+++ b/examples/go/package.json
@@ -9,7 +9,7 @@
   "license": "ISC",
   "dependencies": {},
   "devDependencies": {
-    "serverless-scaleway-functions": ">=0.4.9"
+    "serverless-scaleway-functions": ">=0.4.10"
   },
   "description": ""
 }

--- a/examples/multiple/package.json
+++ b/examples/multiple/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {},
   "devDependencies": {
-    "serverless-scaleway-functions": ">=0.4.9"
+    "serverless-scaleway-functions": ">=0.4.10"
   },
   "description": ""
 }

--- a/examples/nodejs-es-modules/package.json
+++ b/examples/nodejs-es-modules/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "devDependencies": {
     "@scaleway/serverless-functions": "^1.0.2",
-    "serverless-scaleway-functions": ">=0.4.9"
+    "serverless-scaleway-functions": ">=0.4.10"
   },
   "description": ""
 }

--- a/examples/nodejs-schedule/package.json
+++ b/examples/nodejs-schedule/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "devDependencies": {
     "@scaleway/serverless-functions": "^1.0.2",
-    "serverless-scaleway-functions": ">=0.4.9"
+    "serverless-scaleway-functions": ">=0.4.10"
   },
   "description": ""
 }

--- a/examples/nodejs/package.json
+++ b/examples/nodejs/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "devDependencies": {
     "@scaleway/serverless-functions": "^1.0.2",
-    "serverless-scaleway-functions": ">=0.4.9"
+    "serverless-scaleway-functions": ">=0.4.10"
   },
   "description": ""
 }

--- a/examples/php/package.json
+++ b/examples/php/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {},
   "devDependencies": {
-    "serverless-scaleway-functions": ">=0.4.9"
+    "serverless-scaleway-functions": ">=0.4.10"
   },
   "description": ""
 }

--- a/examples/python3/package.json
+++ b/examples/python3/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {},
   "devDependencies": {
-    "serverless-scaleway-functions": ">=0.4.9"
+    "serverless-scaleway-functions": ">=0.4.10"
   },
   "description": ""
 }

--- a/examples/rust/package.json
+++ b/examples/rust/package.json
@@ -9,7 +9,7 @@
   "license": "ISC",
   "dependencies": {},
   "devDependencies": {
-    "serverless-scaleway-functions": ">=0.4.9"
+    "serverless-scaleway-functions": ">=0.4.10"
   },
   "description": ""
 }

--- a/examples/secrets/package.json
+++ b/examples/secrets/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {},
   "devDependencies": {
-    "serverless-scaleway-functions": ">=0.4.9"
+    "serverless-scaleway-functions": ">=0.4.10"
   },
   "description": ""
 }

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@types/node": "^18.15.11",
     "@scaleway/serverless-functions": ">=1.0.2",
-    "serverless-scaleway-functions": ">=0.4.9",
+    "serverless-scaleway-functions": ">=0.4.10",
     "typescript": "^5.0.2"
   }
 }

--- a/logs/lib/getLogs.js
+++ b/logs/lib/getLogs.js
@@ -35,9 +35,11 @@ module.exports = {
   },
 
   printLines(logs) {
-    this.serverless.cli.log("----\n⚠️ WARNING: \"serverless logs\" command is deprecated and will be removed on March 12, 2024. " +
-      "Please use cockpit as soon as possible to continue browsing your logs. " +
-      "Refer to our documentation here: https://www.scaleway.com/en/developers/api/serverless-containers/#logs.\n----")
+    this.serverless.cli.log(
+      '----\n⚠️ WARNING: "serverless logs" command is deprecated and will be removed on March 12, 2024. ' +
+        "Please use cockpit as soon as possible to continue browsing your logs. " +
+        "Refer to our documentation here: https://www.scaleway.com/en/developers/api/serverless-containers/#logs.\n----"
+    );
     for (let i = logs.length - 1; i >= 0; i -= 1) {
       this.serverless.cli.log(logs[i].message);
     }

--- a/logs/lib/getLogs.js
+++ b/logs/lib/getLogs.js
@@ -35,6 +35,9 @@ module.exports = {
   },
 
   printLines(logs) {
+    this.serverless.cli.log("----\n⚠️ WARNING: \"serverless logs\" command is deprecated and will be removed on March 12, 2024. " +
+      "Please use cockpit as soon as possible to continue browsing your logs. " +
+      "Refer to our documentation here: https://www.scaleway.com/en/developers/api/serverless-containers/#logs.\n----")
     for (let i = logs.length - 1; i >= 0; i -= 1) {
       this.serverless.cli.log(logs[i].message);
     }

--- a/logs/lib/getLogs.js
+++ b/logs/lib/getLogs.js
@@ -37,7 +37,7 @@ module.exports = {
   printLines(logs) {
     this.serverless.cli.log(
       '----\n⚠️ WARNING: "serverless logs" command is deprecated and will be removed on March 12, 2024. ' +
-        "Please use cockpit as soon as possible to continue browsing your logs. " +
+        "Please use Cockpit as soon as possible to continue browsing your logs. " +
         "Refer to our documentation here: https://www.scaleway.com/en/developers/api/serverless-containers/#logs.\n----"
     );
     for (let i = logs.length - 1; i >= 0; i -= 1) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-scaleway-functions",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-scaleway-functions",
-      "version": "0.4.9",
+      "version": "0.4.10",
       "license": "MIT",
       "dependencies": {
         "@serverless/utils": "^6.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-scaleway-functions",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Provider plugin for the Serverless Framework v1.x which adds support for Scaleway Functions.",
   "main": "index.js",
   "author": "scaleway.com",


### PR DESCRIPTION
## Summary

**_What's changed?_**

Add a deprecation message when running "serverless logs" command. 

**_Why do we need this?_**

This follows the deprecation of `/logs` endpoint: https://github.com/scaleway/docs-content/pull/2715. We want to display a warning message here during 1 month, so people are not surprised when we are going to remove the command and `/logs` endpoint.

**_How have you tested it?_**

- created a dummy python function
- ran `serverless logs` command:

![image](https://github.com/scaleway/serverless-scaleway-functions/assets/26850303/e729fc20-435b-428b-987f-000c45b6ff6e)

## Checklist

- [X] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [X] I have updated the relevant documentation