### PR TITLE
docs(README): fix disabled http option is not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ functions:
     # Runtime for this function, allows overriding provider.runtime
     runtime: node20
 
-    # How to handle HTTP. Options: enabled (allow HTTP), disabled (block HTTP), or redirected (redirect HTTP -> HTTPS)
+    # How to handle HTTP. Options: enabled (allow HTTP), or redirected (redirect HTTP -> HTTPS)
     httpOption: enabled
 
     # Controls privacy of the function. Options: public (no authentication), private (token-based authentication)

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ custom:
       # Value in string format ex: "300s" (default: 300 seconds)
       timeout: 300s
 
-      # How to handle HTTP. Options: enabled (allow HTTP), disabled (block HTTP), or redirected (redirect HTTP -> HTTPS)
+      # How to handle HTTP. Options: enabled (allow HTTP), or redirected (redirect HTTP -> HTTPS)
       httpOption: enabled
 
       # Controls privacy of the container. Options: public (no authentication), private (token-based authentication)


### PR DESCRIPTION
## Summary

**_What's changed?_**

- Fixed a small typo on the README

**_Why do we need this?_**

- Typo is misleading: we do not have a http `disabled` option, call will not be accepted by the API

**_How have you tested it?_**

- Docs changes :white_check_mark: 

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details

Fixes https://github.com/scaleway/serverless-scaleway-functions/issues/208