### PR TITLE
feat(deploy): add sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ functions:
     # How to handle HTTP. Options: enabled (allow HTTP), disabled (block HTTP), or redirected (redirect HTTP -> HTTPS)
     httpOption: enabled
 
+    # Execution environment to use when running the function. Options: v1 (legacy), v2 (recommended, with improved cold starts)
+    sandbox: v2
+
     # Controls privacy of the function. Options: public (no authentication), private (token-based authentication)
     privacy: public
 
@@ -214,6 +217,9 @@ custom:
 
       # How to handle HTTP. Options: enabled (allow HTTP), disabled (block HTTP), or redirected (redirect HTTP -> HTTPS)
       httpOption: enabled
+
+      # Execution environment to use when running the container. Options: v1 (legacy), v2 (recommended, with improved cold starts)
+      sandbox: v2
 
       # Controls privacy of the container. Options: public (no authentication), private (token-based authentication)
       privacy: public

--- a/deploy/lib/createContainers.js
+++ b/deploy/lib/createContainers.js
@@ -103,13 +103,14 @@ module.exports = {
       privacy: container.privacy,
       port: container.port,
       http_option: container.httpOption,
+      sandbox: container.sandbox,
     };
 
     // checking if there is custom_domains set on container creation.
     if (container.custom_domains && container.custom_domains.length > 0) {
       this.serverless.cli.log(
         "WARNING: custom_domains are available on container update only. " +
-          "Redeploy your container to apply custom domains. Doc : https://www.scaleway.com/en/docs/compute/containers/how-to/add-a-custom-domain-to-a-container/"
+        "Redeploy your container to apply custom domains. Doc : https://www.scaleway.com/en/docs/compute/containers/how-to/add-a-custom-domain-to-a-container/"
       );
     }
 

--- a/deploy/lib/createContainers.js
+++ b/deploy/lib/createContainers.js
@@ -110,7 +110,7 @@ module.exports = {
     if (container.custom_domains && container.custom_domains.length > 0) {
       this.serverless.cli.log(
         "WARNING: custom_domains are available on container update only. " +
-        "Redeploy your container to apply custom domains. Doc : https://www.scaleway.com/en/docs/compute/containers/how-to/add-a-custom-domain-to-a-container/"
+          "Redeploy your container to apply custom domains. Doc : https://www.scaleway.com/en/docs/compute/containers/how-to/add-a-custom-domain-to-a-container/"
       );
     }
 

--- a/deploy/lib/createFunctions.js
+++ b/deploy/lib/createFunctions.js
@@ -195,7 +195,7 @@ Runtime lifecycle doc : https://www.scaleway.com/en/docs/compute/functions/refer
     if (func.custom_domains && func.custom_domains.length > 0) {
       this.serverless.cli.log(
         "WARNING: custom_domains are available on function update only. " +
-        "Redeploy your function to apply custom domains. Doc : https://www.scaleway.com/en/docs/compute/functions/how-to/add-a-custom-domain-name-to-a-function/"
+          "Redeploy your function to apply custom domains. Doc : https://www.scaleway.com/en/docs/compute/functions/how-to/add-a-custom-domain-name-to-a-function/"
       );
     }
 

--- a/deploy/lib/createFunctions.js
+++ b/deploy/lib/createFunctions.js
@@ -181,6 +181,7 @@ Runtime lifecycle doc : https://www.scaleway.com/en/docs/compute/functions/refer
       privacy: func.privacy,
       domain_name: func.domain_name,
       http_option: func.httpOption,
+      sandbox: func.sandbox,
     };
 
     const availableRuntimes = await this.listRuntimes();
@@ -194,7 +195,7 @@ Runtime lifecycle doc : https://www.scaleway.com/en/docs/compute/functions/refer
     if (func.custom_domains && func.custom_domains.length > 0) {
       this.serverless.cli.log(
         "WARNING: custom_domains are available on function update only. " +
-          "Redeploy your function to apply custom domains. Doc : https://www.scaleway.com/en/docs/compute/functions/how-to/add-a-custom-domain-name-to-a-function/"
+        "Redeploy your function to apply custom domains. Doc : https://www.scaleway.com/en/docs/compute/functions/how-to/add-a-custom-domain-name-to-a-function/"
       );
     }
 

--- a/examples/nodejs/serverless.yml
+++ b/examples/nodejs/serverless.yml
@@ -20,6 +20,7 @@ functions:
   first:
     handler: handler.handle
     httpOption: redirected
+    sandbox: v2
     # description: ""
     # Local environment variables - used only in given function
     env:

--- a/examples/nodejs/serverless.yml
+++ b/examples/nodejs/serverless.yml
@@ -3,8 +3,8 @@ configValidationMode: off
 singleSource: false
 provider:
   name: scaleway
-  runtime: node16 # Available node runtimes are listed in documentation
-  # Global Environment variables - used in every functions
+  runtime: node22 # Available node runtimes are listed in documentation
+  # Global Environment variables - used in every function
   env:
     test: test
 
@@ -21,6 +21,7 @@ functions:
     handler: handler.handle
     httpOption: redirected
     sandbox: v2
+    memoryLimit: 1024
     # description: ""
     # Local environment variables - used only in given function
     env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "eslint-plugin-import": "^2.27.5",
         "fs-extra": "^11.1.1",
         "jest": "^29.6.1",
+        "prettier": "^2.8.8",
         "rewire": "^6.0.0"
       }
     },
@@ -6311,6 +6312,21 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "test:shared": "jest tests/shared",
     "test:triggers": "jest tests/triggers",
     "coverage": "jest --coverage",
-    "lint": "eslint . --cache"
+    "lint": "eslint . --cache",
+    "check-format": "prettier --check .",
+    "format": "prettier --write ."
   },
   "homepage": "https://github.com/scaleway/serverless-scaleway-functions",
   "keywords": [
@@ -65,6 +67,7 @@
     "eslint-plugin-import": "^2.27.5",
     "fs-extra": "^11.1.1",
     "jest": "^29.6.1",
+    "prettier": "^2.8.8",
     "rewire": "^6.0.0"
   }
 }


### PR DESCRIPTION
## Summary

**_What's changed?_**

* Add support for `sandbox` parameter for functions/containers.

**_Why do we need this?_**

* Allow Serverless Framework users to update to Sandbox V2

**_How have you tested it?_**

* Update the example used in E2E with `sandbox: v2`
* Deployed a function with the `sandbox: v2` :white_check_mark: 

![image](https://github.com/scaleway/serverless-scaleway-functions/assets/49867608/8e479b35-5759-44df-a300-4c3edfad4e09)

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR -> this repo has no unit test, updated E2E test to use Sandbox V2
- [x] I have updated the relevant documentation

## Details
