### PR TITLE
fix(deployment): add sandbox param in update call

### DIFF
--- a/deploy/lib/createContainers.js
+++ b/deploy/lib/createContainers.js
@@ -143,6 +143,7 @@ module.exports = {
       privacy: container.privacy,
       port: container.port,
       http_option: container.httpOption,
+      sandbox: container.sandbox,
     };
 
     this.serverless.cli.log(`Updating container ${container.name}...`);

--- a/deploy/lib/createFunctions.js
+++ b/deploy/lib/createFunctions.js
@@ -224,6 +224,7 @@ Runtime lifecycle doc : https://www.scaleway.com/en/docs/compute/functions/refer
       privacy: func.privacy,
       domain_name: func.domain_name,
       http_option: func.httpOption,
+      sandbox: func.sandbox,
     };
 
     const availableRuntimes = await this.listRuntimes();


### PR DESCRIPTION
## Summary

**_What's changed?_**

- Sandbox param was missing when updating function/container

**_Why do we need this?_**

- This prevents users from changing the Sandbox of their existing functions :/

**_How have you tested it?_**

- Tested locally :white_check_mark: 

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details
