### PR TITLE
fix(container): honor .dockerignore when building a container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.16
+
+### Fixed
+
+- Honor `.dockerignore` when building a container #277
+
 ## 0.4.15
 
 ### Added

--- a/examples/go/package-lock.json
+++ b/examples/go/package-lock.json
@@ -13,7 +13,7 @@
       }
     },
     "../..": {
-      "version": "0.4.15",
+      "version": "0.4.16",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22,8 +22,7 @@
         "axios": "^1.4.0",
         "bluebird": "^3.7.2",
         "dockerode": "^3.3.5",
-        "js-yaml": "^4.1.0",
-        "tar-fs": "^2.1.1"
+        "js-yaml": "^4.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-scaleway-functions",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-scaleway-functions",
-      "version": "0.4.15",
+      "version": "0.4.16",
       "license": "MIT",
       "dependencies": {
         "@serverless/utils": "^6.13.1",
@@ -14,8 +14,7 @@
         "axios": "^1.4.0",
         "bluebird": "^3.7.2",
         "dockerode": "^4.0.6",
-        "js-yaml": "^4.1.0",
-        "tar-fs": "^2.1.1"
+        "js-yaml": "^4.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-scaleway-functions",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "description": "Provider plugin for the Serverless Framework v3.x which adds support for Scaleway Functions.",
   "main": "index.js",
   "author": "scaleway.com",
@@ -57,8 +57,7 @@
     "axios": "^1.4.0",
     "bluebird": "^3.7.2",
     "dockerode": "^4.0.6",
-    "js-yaml": "^4.1.0",
-    "tar-fs": "^2.1.1"
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/shared/api/utils.js
+++ b/shared/api/utils.js
@@ -1,7 +1,7 @@
 const axios = require("axios");
 const https = require("https");
 
-const version = "0.4.15";
+const version = "0.4.16";
 
 const invalidArgumentsType = "invalid_arguments";
 

--- a/tests/containers/containers.test.js
+++ b/tests/containers/containers.test.js
@@ -3,7 +3,6 @@
 const Docker = require("dockerode");
 const fs = require("fs");
 const path = require("path");
-const tar = require("tar-fs");
 
 const { afterAll, beforeAll, describe, it, expect } = require("@jest/globals");
 
@@ -113,9 +112,7 @@ describe("Service Lifecyle Integration Test", () => {
 
     await docker.checkAuth(registryAuth);
 
-    const tarStream = tar.pack(path.join(tmpDir, "my-container"));
-
-    await docker.buildImage(tarStream, {
+    await docker.buildImage({context: path.join(tmpDir, "my-container"), src: ["Dockerfile", "server.py", "requirements.txt"]}, {
       t: imageName,
       registryconfig: registryAuth,
     });


### PR DESCRIPTION
## Summary

**_What's changed?_**

When building a container, honor `.dockerignore` present at the root of the build context.

Also bumping the version in the same PR (0.4.15 => 0.4.16 since it's a bug fix).

Bonus: we don't need `tar-fs` library anymore!

**_Why do we need this?_**

Today, `.dockerignore` file at the root of the build context is ignored. Whatever file you list inside it, it will be present in the built image if you do `COPY . .` for example.

The library used under the hood ([dockerode](https://github.com/apocas/dockerode)) supports this, but **not** if we pass a tar stream when building. We need to pass a list of files so files in `.dockerignore` can be excluded.

So, the only way seems to be to list all the files in the build context, and pass them to dockerode so it can filter afterwards.

**_How have you tested it?_**

Pretty simple example:

`serverless.yml`:

```yml
service: test
configValidationMode: off
provider:
  name: scaleway

plugins:
  - serverless-scaleway-functions

package:
  patterns:
    - "!node_modules/**"
    - "!.gitignore"
    - "!.git/**"

custom:
  containers:
    test:
      directory: container
      port: 8000
      memoryLimit: 1000
      cpuLimit: 1000
```

The `container/` folder looks like:

```
container/
  |-- .dockerignore
  |-- Dockerfile
  |-- dir1
       |-- dir2
            |-- test1
            |-- test2
  |-- hello
  |-- world
```

`Dockerfile` is:

```Dockerfile
FROM python:3.13-alpine

WORKDIR /app

COPY . .

CMD ["python3", "-m", "http.server"]
```

And `.dockerignore` contains:

```
world
dir1/dir2/test2
```

Once deployed (`serverless deploy`), the files shown are just: `hello` and `dir1/dir2/test`. Other files have been excluded. This can also be checked in the built image.

## Checklist

- [X] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details
