### PR TITLE
fix(deploy): avoid wrong params for messaging triggers on containers

### DIFF
--- a/deploy/lib/deployTriggers.js
+++ b/deploy/lib/deployTriggers.js
@@ -79,13 +79,13 @@ module.exports = {
         });
       }
       if ("nats" in event) {
-        this.createMessageTrigger(application.id, {
+        this.createMessageTrigger(application.id, isFunction, {
           name: event.nats.name,
           scw_nats_config: event.nats.scw_nats_config,
         });
       }
       if ("sqs" in event) {
-        this.createMessageTrigger(application.id, {
+        this.createMessageTrigger(application.id, isFunction, {
           name: event.sqs.name,
           scw_sqs_config: {
             queue: event.sqs.queue,

--- a/shared/api/triggers.js
+++ b/shared/api/triggers.js
@@ -45,12 +45,18 @@ module.exports = {
       .catch(manageError);
   },
 
-  createMessageTrigger(applicationId, params) {
+  createMessageTrigger(applicationId, isFunction, params) {
     let payload = {
       ...params,
       function_id: applicationId,
     };
 
+    if (!isFunction) {
+      payload = {
+        ...params,
+        container_id: applicationId,
+      };
+    }
     return this.apiManager
       .post("triggers", payload)
       .then((response) => response.data)


### PR DESCRIPTION
## Summary

Closes #310

**_What's changed?_**

- Pass `container_id` when creating a SQS/NATS trigger on a container

**_Why do we need this?_**

- Currently, the SQS/NATS triggers are not working with Serverless Containers

**_How have you tested it?_**

- Deployed a SQS trigger on the example container :white_check_mark: 

<img width="1143" height="129" alt="image" src="https://github.com/user-attachments/assets/513f82b7-0873-4a85-bde7-bb05099a9e50" />

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details
