### PR TITLE
chore: use trusted publishers + bump version before release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-22.04
@@ -22,5 +26,3 @@ jobs:
 
       - name: "Publish package on NPM"
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.4.18
+
+### Fixed
+
+- Messaging (NATS/SQS) triggers now properly work with Serverless Containers #311
+
 ## 0.4.17
 
 ### Added

--- a/examples/go/package-lock.json
+++ b/examples/go/package-lock.json
@@ -13,7 +13,7 @@
       }
     },
     "../..": {
-      "version": "0.4.17",
+      "version": "0.4.18",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-scaleway-functions",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-scaleway-functions",
-      "version": "0.4.17",
+      "version": "0.4.18",
       "license": "MIT",
       "dependencies": {
         "@serverless/utils": "^6.13.1",
@@ -4077,7 +4077,7 @@
         "event-emitter": "^0.3.5",
         "ext": "^1.7.0",
         "ignore": "^5.3.2",
-        "memoizee": "^0.4.17",
+        "memoizee": "^0.4.18",
         "type": "^2.7.3"
       },
       "engines": {
@@ -5662,8 +5662,8 @@
       }
     },
     "node_modules/memoizee": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.17.tgz",
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.18.tgz",
       "integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-scaleway-functions",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "Provider plugin for the Serverless Framework v3.x which adds support for Scaleway Functions.",
   "main": "index.js",
   "author": "scaleway.com",

--- a/shared/api/utils.js
+++ b/shared/api/utils.js
@@ -1,7 +1,7 @@
 const axios = require("axios");
 const https = require("https");
 
-const version = "0.4.17";
+const version = "0.4.18";
 
 const invalidArgumentsType = "invalid_arguments";
 


### PR DESCRIPTION
## Summary

**_What's changed?_**

- Use trusted publishers
- Bump to v0.4.18

**_Why do we need this?_**

- Make a new release :rocket: 

**_How have you tested it?_**

- Checked NPM docs: https://docs.npmjs.com/trusted-publishers (read it thoroughly)

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details
