### PR TITLE
fix(deps): lock dependencies again to fix find and replace mistake

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4077,7 +4077,7 @@
         "event-emitter": "^0.3.5",
         "ext": "^1.7.0",
         "ignore": "^5.3.2",
-        "memoizee": "^0.4.18",
+        "memoizee": "^0.4.17",
         "type": "^2.7.3"
       },
       "engines": {
@@ -5662,8 +5662,8 @@
       }
     },
     "node_modules/memoizee": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.18.tgz",
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.17.tgz",
       "integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
## Summary

**_What's changed?_**

- Restore package-lock.json from commit [3acf535](https://github.com/scaleway/serverless-scaleway-functions/commit/3acf53591b10bb026757629705acdb39fc081116)
- Run `npm i --package-lock-only` 

**_Why do we need this?_**

- When replacing the `0.4.17` string, I was way too agressive and ended-up overwriting a version which I did not catch :/ 

**_How have you tested it?_**

- Ran `npm i` locally on a blank directory, did not run into any issue

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details
