### PR TITLE
fix(npm): use correct repo syntax in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "scaleway.com",
   "license": "MIT",
   "repository": {
-    "git": "https://github.com/scaleway/serverless-scaleway-functions"
+    "type": "git",
+    "url": "https://github.com/scaleway/serverless-scaleway-functions.git"
   },
   "scripts": {
     "clean-up": "node tests/teardown.js",


### PR DESCRIPTION
## Summary

**_What's changed?_**

- Use correct repository syntax

**_Why do we need this?_**

- Publish job is failing yet again: https://github.com/scaleway/serverless-scaleway-functions/actions/runs/20094471901
- The error seems to be around a missing repository to check provenance from our `package.json` itself

**_How have you tested it?_**

- Checked docs: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details
