### PR TITLE
chore: bump version before release + fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.5.0
+
+### Added
+
+- Implement `buildArgs` parameter for container build
+
+### Changed
+
+- Handle deprecation of `redeploy: false` parameter in `UpdateContainer`
+
+### Fixed
+
+- When pushing a built to the remote registry, use the correct credentials instead of relying on the local docker configuration.
+
 ## 0.4.18
 
 ### Fixed

--- a/deploy/lib/buildAndPushContainers.js
+++ b/deploy/lib/buildAndPushContainers.js
@@ -90,7 +90,11 @@ function validateContainerConfigBeforeBuild(containerConfig) {
   }
 }
 
-async function buildAndPushContainer(authConfig, containerConfig) {
+async function buildAndPushContainer(
+  registryAuth,
+  authConfig,
+  containerConfig
+) {
   const { name, directory, buildArgs } = containerConfig;
   const imageName = `${this.namespace.registry_endpoint}/${name}:latest`;
 
@@ -100,7 +104,7 @@ async function buildAndPushContainer(authConfig, containerConfig) {
 
   let buildOptions = {
     t: imageName,
-    authconfig: authConfig,
+    registryconfig: registryAuth,
   };
 
   if (buildArgs !== undefined) {
@@ -188,7 +192,12 @@ module.exports = {
       .map((containerConfig) => {
         validateContainerConfigBeforeBuild(containerConfig);
 
-        return buildAndPushContainer.call(this, auth, containerConfig);
+        return buildAndPushContainer.call(
+          this,
+          registryAuth,
+          auth,
+          containerConfig
+        );
       });
 
     await Promise.all(buildPromises);

--- a/deploy/lib/buildAndPushContainers.js
+++ b/deploy/lib/buildAndPushContainers.js
@@ -171,7 +171,7 @@ module.exports = {
     const registryAuth = { [`rg.${this.provider.scwRegion}.scw.cloud`]: auth };
 
     try {
-      await docker.checkAuth(auth);
+      await docker.checkAuth(registryAuth);
     } catch (err) {
       throw new Error(`Docker error : ${err}`);
     }

--- a/deploy/lib/buildAndPushContainers.js
+++ b/deploy/lib/buildAndPushContainers.js
@@ -90,11 +90,7 @@ function validateContainerConfigBeforeBuild(containerConfig) {
   }
 }
 
-async function buildAndPushContainer(
-  registryAuth,
-  authConfig,
-  containerConfig
-) {
+async function buildAndPushContainer(authConfig, containerConfig) {
   const { name, directory, buildArgs } = containerConfig;
   const imageName = `${this.namespace.registry_endpoint}/${name}:latest`;
 
@@ -104,7 +100,7 @@ async function buildAndPushContainer(
 
   let buildOptions = {
     t: imageName,
-    registryconfig: registryAuth,
+    authconfig: authConfig,
   };
 
   if (buildArgs !== undefined) {
@@ -192,12 +188,7 @@ module.exports = {
       .map((containerConfig) => {
         validateContainerConfigBeforeBuild(containerConfig);
 
-        return buildAndPushContainer.call(
-          this,
-          registryAuth,
-          auth,
-          containerConfig
-        );
+        return buildAndPushContainer.call(this, auth, containerConfig);
       });
 
     await Promise.all(buildPromises);

--- a/deploy/lib/buildAndPushContainers.js
+++ b/deploy/lib/buildAndPushContainers.js
@@ -100,7 +100,7 @@ async function buildAndPushContainer(authConfig, containerConfig) {
 
   let buildOptions = {
     t: imageName,
-    authconfig: auth,
+    authconfig: authConfig,
   };
 
   if (buildArgs !== undefined) {

--- a/deploy/lib/buildAndPushContainers.js
+++ b/deploy/lib/buildAndPushContainers.js
@@ -161,7 +161,7 @@ module.exports = {
     const auth = {
       username: "any",
       password: this.provider.scwToken,
-      serveraddress: `rg.${this.provider.region}.scw.cloud`,
+      serveraddress: `rg.${this.namespace.region}.scw.cloud`,
     };
 
     try {

--- a/deploy/lib/buildAndPushContainers.js
+++ b/deploy/lib/buildAndPushContainers.js
@@ -90,7 +90,11 @@ function validateContainerConfigBeforeBuild(containerConfig) {
   }
 }
 
-async function buildAndPushContainer(authConfig, containerConfig) {
+async function buildAndPushContainer(
+  registryAuth,
+  authConfig,
+  containerConfig
+) {
   const { name, directory, buildArgs } = containerConfig;
   const imageName = `${this.namespace.registry_endpoint}/${name}:latest`;
 
@@ -100,7 +104,7 @@ async function buildAndPushContainer(authConfig, containerConfig) {
 
   let buildOptions = {
     t: imageName,
-    authconfig: authConfig,
+    registryconfig: registryAuth,
   };
 
   if (buildArgs !== undefined) {
@@ -161,11 +165,12 @@ module.exports = {
     const auth = {
       username: "any",
       password: this.provider.scwToken,
-      serveraddress: `rg.${this.namespace.region}.scw.cloud`,
     };
 
+    // Used for building, see https://docs.docker.com/engine/api/v1.37/#tag/Image/operation/ImageBuild
+    const registryAuth = { [`rg.${this.provider.scwRegion}.scw.cloud`]: auth };
+
     try {
-      // validate the simple auth object (including serveraddress), not the map
       await docker.checkAuth(auth);
     } catch (err) {
       throw new Error(`Docker error : ${err}`);
@@ -187,7 +192,12 @@ module.exports = {
       .map((containerConfig) => {
         validateContainerConfigBeforeBuild(containerConfig);
 
-        return buildAndPushContainer.call(this, auth, containerConfig);
+        return buildAndPushContainer.call(
+          this,
+          registryAuth,
+          auth,
+          containerConfig
+        );
       });
 
     await Promise.all(buildPromises);

--- a/deploy/lib/createContainers.js
+++ b/deploy/lib/createContainers.js
@@ -200,7 +200,6 @@ module.exports = {
     }
 
     const params = {
-      redeploy: false,
       environment_variables: container.env,
       secret_environment_variables: await secrets.mergeSecretEnvVars(
         foundContainer.secret_environment_variables,

--- a/deploy/lib/createContainers.js
+++ b/deploy/lib/createContainers.js
@@ -187,7 +187,7 @@ module.exports = {
 
   async updateSingleContainer(container, foundContainer) {
     // Assign domains to the container before updating it, as it's not possible to manage domains
-    // while the container is updating or pending, and we already wait for the container 
+    // while the container is updating or pending, and we already wait for the container
     // to be in a final status before updating it.
     // => This order of operation is simpler and does not require performing two separate waits.
     this.applyDomainsContainer(foundContainer.id, container.custom_domains);

--- a/deploy/lib/createContainers.js
+++ b/deploy/lib/createContainers.js
@@ -186,6 +186,12 @@ module.exports = {
   },
 
   async updateSingleContainer(container, foundContainer) {
+    // Assign domains to the container before updating it, as it's not possible to manage domains
+    // while the container is updating or pending, and we already wait for the container 
+    // to be in a final status before updating it.
+    // => This order of operation is simpler and does not require performing two separate waits.
+    this.applyDomainsContainer(foundContainer.id, container.custom_domains);
+
     let privateNetworkId = container.privateNetworkId;
     const hasToDeletePrivateNetwork =
       foundContainer.private_network_id && !container.privateNetworkId;
@@ -226,9 +232,6 @@ module.exports = {
     }
 
     this.serverless.cli.log(`Updating container ${container.name}...`);
-
-    // assign domains
-    this.applyDomainsContainer(foundContainer.id, container.custom_domains);
 
     return this.updateContainer(foundContainer.id, params).then(
       (updatedContainer) => {

--- a/deploy/lib/deployContainers.js
+++ b/deploy/lib/deployContainers.js
@@ -18,7 +18,7 @@ module.exports = {
 
           this.waitDomainsAreDeployedContainer(container.id).then((domains) => {
             domains.forEach((domain) => {
-              this.serverless.cli.log(`Domain ready : ${domain.hostname}`);
+              this.serverless.cli.log(`Domain ready: ${domain.hostname}`);
             });
           });
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-scaleway-functions",
-  "version": "0.4.18",
+  "version": "0.5.0",
   "description": "Provider plugin for the Serverless Framework v3.x which adds support for Scaleway Functions.",
   "main": "index.js",
   "author": "scaleway.com",

--- a/shared/api/utils.js
+++ b/shared/api/utils.js
@@ -1,7 +1,7 @@
 const axios = require("axios");
 const https = require("https");
 
-const version = "0.4.18";
+const version = "0.5.0";
 
 const invalidArgumentsType = "invalid_arguments";
 

--- a/tests/containers/containers.test.js
+++ b/tests/containers/containers.test.js
@@ -122,7 +122,9 @@ describe("Service Lifecyle Integration Test", () => {
         { t: imageName },
         (err, stream) => {
           if (err) return reject(err);
-          docker.modem.followProgress(stream, (err, res) => (err ? reject(err) : resolve(res)));
+          docker.modem.followProgress(stream, (err, res) =>
+            err ? reject(err) : resolve(res)
+          );
         }
       );
     });
@@ -131,13 +133,12 @@ describe("Service Lifecyle Integration Test", () => {
 
     // Push image and wait for completion
     await new Promise((resolve, reject) => {
-      image.push(
-        { authconfig: auth },
-        (err, stream) => {
-          if (err) return reject(err);
-          docker.modem.followProgress(stream, (err, res) => (err ? reject(err) : resolve(res)));
-        }
-      );
+      image.push({ authconfig: auth }, (err, stream) => {
+        if (err) return reject(err);
+        docker.modem.followProgress(stream, (err, res) =>
+          err ? reject(err) : resolve(res)
+        );
+      });
     });
 
     // registry lag

--- a/tests/containers/containers.test.js
+++ b/tests/containers/containers.test.js
@@ -123,15 +123,12 @@ describe("Service Lifecyle Integration Test", () => {
       }
     );
     const image = docker.getImage(imageName);
-    await image.push(auth);
+    await image.push({ authconfig: auth });
 
     // registry lag
     await sleep(60000);
 
-    const params = {
-      redeploy: false,
-      registry_image: imageName,
-    };
+    const params = {registry_image: imageName};
     await api
       .updateContainer(namespace.containers[0].id, params)
       .catch((err) => console.error(err));

--- a/tests/containers/containers.test.js
+++ b/tests/containers/containers.test.js
@@ -128,7 +128,7 @@ describe("Service Lifecyle Integration Test", () => {
     // registry lag
     await sleep(60000);
 
-    const params = {registry_image: imageName};
+    const params = { registry_image: imageName };
     await api
       .updateContainer(namespace.containers[0].id, params)
       .catch((err) => console.error(err));

--- a/tests/containers/containers.test.js
+++ b/tests/containers/containers.test.js
@@ -106,22 +106,15 @@ describe("Service Lifecyle Integration Test", () => {
       password: scwToken,
     };
 
-    const regEndpoint = `rg.${scwRegion}.scw.cloud`;
-    const registryAuth = {};
-    registryAuth[regEndpoint] = auth;
-
-    await docker.checkAuth(auth);
-
     // Build image and wait for completion
-    // TODO: we can be rate-limited by DockerHub here, and
-    // there's not much we can do about it :/
     await new Promise((resolve, reject) => {
       docker.buildImage(
         {
           context: path.join(tmpDir, "my-container"),
           src: ["Dockerfile", "server.py", "requirements.txt"],
         },
-        { t: imageName },
+        // Ensure no credentials are sent to Docker Hub.
+        { t: imageName, authconfig: {} },
         (err, stream) => {
           if (err) return reject(err);
           docker.modem.followProgress(stream, (err, res) =>

--- a/tests/containers/containers.test.js
+++ b/tests/containers/containers.test.js
@@ -113,6 +113,8 @@ describe("Service Lifecyle Integration Test", () => {
     await docker.checkAuth(auth);
 
     // Build image and wait for completion
+    // TODO: we can be rate-limited by DockerHub here, and
+    // there's not much we can do about it :/
     await new Promise((resolve, reject) => {
       docker.buildImage(
         {
@@ -203,6 +205,8 @@ describe("Service Lifecyle Integration Test", () => {
       "registryImage: docker.io/library/nginx:latest"
     );
     replaceTextInFile("serverless.yml", "# port: 8080", "port: 80");
+    // Need to change the probe path to / since Nginx doesn't have /health endpoint
+    replaceTextInFile("serverless.yml", "httpPath: /health", "httpPath: /");
     serverlessDeploy(options);
   });
 

--- a/tests/containers/containers.test.js
+++ b/tests/containers/containers.test.js
@@ -110,20 +110,35 @@ describe("Service Lifecyle Integration Test", () => {
     const registryAuth = {};
     registryAuth[regEndpoint] = auth;
 
-    await docker.checkAuth(registryAuth);
+    await docker.checkAuth(auth);
 
-    await docker.buildImage(
-      {
-        context: path.join(tmpDir, "my-container"),
-        src: ["Dockerfile", "server.py", "requirements.txt"],
-      },
-      {
-        t: imageName,
-        registryconfig: registryAuth,
-      }
-    );
+    // Build image and wait for completion
+    await new Promise((resolve, reject) => {
+      docker.buildImage(
+        {
+          context: path.join(tmpDir, "my-container"),
+          src: ["Dockerfile", "server.py", "requirements.txt"],
+        },
+        { t: imageName },
+        (err, stream) => {
+          if (err) return reject(err);
+          docker.modem.followProgress(stream, (err, res) => (err ? reject(err) : resolve(res)));
+        }
+      );
+    });
+
     const image = docker.getImage(imageName);
-    await image.push({ authconfig: auth });
+
+    // Push image and wait for completion
+    await new Promise((resolve, reject) => {
+      image.push(
+        { authconfig: auth },
+        (err, stream) => {
+          if (err) return reject(err);
+          docker.modem.followProgress(stream, (err, res) => (err ? reject(err) : resolve(res)));
+        }
+      );
+    });
 
     // registry lag
     await sleep(60000);
@@ -175,6 +190,12 @@ describe("Service Lifecyle Integration Test", () => {
   });
 
   it("should deploy with registry image specified", () => {
+    // Instead of building the container from the directory, we specify a registry image.
+    replaceTextInFile(
+      "serverless.yml",
+      "directory: my-container",
+      "# directory: my-container"
+    );
     replaceTextInFile(
       "serverless.yml",
       '# registryImage: ""',

--- a/tests/containers/containers_private_registry.test.js
+++ b/tests/containers/containers_private_registry.test.js
@@ -101,7 +101,7 @@ describe("Build and deploy on container with a base image private", () => {
     };
 
     await new Promise((resolve, reject) => {
-      image.push({ authconfig: auth }, (err, stream) => {
+      privateRegistryImage.push({ authconfig: auth }, (err, stream) => {
         if (err) return reject(err);
         docker.modem.followProgress(stream, (err, res) =>
           err ? reject(err) : resolve(res)

--- a/tests/containers/containers_private_registry.test.js
+++ b/tests/containers/containers_private_registry.test.js
@@ -96,8 +96,10 @@ describe("Build and deploy on container with a base image private", () => {
     );
     await privateRegistryImage.push({
       stream: false,
-      username: "nologin",
-      password: scwToken,
+      authconfig: {
+        username: "nologin",
+        password: scwToken,
+      },
     });
     await privateRegistryImage.remove();
   });

--- a/tests/utils/misc/index.js
+++ b/tests/utils/misc/index.js
@@ -110,10 +110,21 @@ function sleep(ms) {
 
 async function createProject() {
   const accountApi = new AccountApi(ACCOUNT_API_URL, secretKey);
-  return accountApi.createProject({
+
+  // Unfortunately, there's a small delay between the creation of a project and its availability for API calls.
+  // We wait 1 minute to ensure there's no issue with IAM cache.
+  const project = await accountApi.createProject({
     name: `test-slsframework-${crypto.randomBytes(6).toString("hex")}`,
     organization_id: organizationId,
   });
+  
+  console.log(`Project ${project.name} created, waiting for it to be available...`);
+  
+  await sleep(60000);
+
+  console.log(`Project ${project.name} is now available.`);
+ 
+  return project;
 }
 
 module.exports = {

--- a/tests/utils/misc/index.js
+++ b/tests/utils/misc/index.js
@@ -117,13 +117,15 @@ async function createProject() {
     name: `test-slsframework-${crypto.randomBytes(6).toString("hex")}`,
     organization_id: organizationId,
   });
-  
-  console.log(`Project ${project.name} created, waiting for it to be available...`);
-  
+
+  console.log(
+    `Project ${project.name} created, waiting for it to be available...`
+  );
+
   await sleep(60000);
 
   console.log(`Project ${project.name} is now available.`);
- 
+
   return project;
 }
 


### PR DESCRIPTION
## Summary

**_What's changed?_**

- Bump version to `0.5.0` to prepare next release
- Implement some small fixes to ensure compatibility with both v1beta1 and v1 APIs

**_Why do we need this?_**

- When implementing my previous MRs, I ended-up breaking the v1beta1 code path by not deploying upon creation. This is now fixed.
- We also always redeploy on update now, to preserve the current behavior of SLS FW. The code to accomplish this is definitely on the hacky side, but this solution does not involve significant changes.

**_How have you tested it?_**

- Tested locally :white_check_mark: 
  - I tested most (I would say all but maybe I missed some) features of SLS FW using both the v1beta1 and v1 and it seems to work well. 

## Checklist

- [x] I have reviewed this myself
- [x] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details
