### PR TITLE
fix(containers): do not crash because of unhandled error

### DIFF
--- a/shared/api/containers.js
+++ b/shared/api/containers.js
@@ -113,13 +113,15 @@ module.exports = {
         return container;
       })
       .catch((err) => {
-        // There's no "deleted" status for container,
-        // so if the container is not found we consider it as deleted and return null
-        if (err.response.status === 404) {
-          return null;
+        // toleration on 4XX errors because on some status, for example deleting the API
+        // will return a 404 err code if item has been deleted.
+        if (err.response === undefined) {
+          // if we have a raw Error
+          throw err;
+        } else if (err.response.status >= 500) {
+          // if we have a CustomError, we can check the status
+          throw new Error(err);
         }
-
-        throw new Error(err);
       });
   },
 

--- a/shared/api/functions.js
+++ b/shared/api/functions.js
@@ -115,7 +115,7 @@ module.exports = {
         return func;
       })
       .catch((err) => {
-        // toleration on 4XX errors because on some status, for exemple deleting the API
+        // toleration on 4XX errors because on some status, for example deleting the API
         // will return a 404 err code if item has been deleted.
         if (err.response === undefined) {
           // if we have a raw Error


### PR DESCRIPTION
## Summary

**_What's changed?_**

- Fix a bug where if the container is in error, we run a `throw Error`... but then in the catch statement, we try to access `error.response` which is obviously undefined for untyped errors like this. We should just forward it in this case
- Make function and container error handling consistent

Massive thanks to @lunhenry for the suggestion: https://github.com/scaleway/serverless-scaleway-functions/issues/323#issuecomment-4182892000 

**_Why do we need this?_**

- Currently, containers in error return an obscure error message instead of the helpful one set by the API

**_How have you tested it?_**

- N/A

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details

Closes #323 

For reviewers, I thought I broke it in: https://github.com/scaleway/serverless-scaleway-functions/pull/320/changes?diff=split#diff-a56d1acd44a4b5b77776b9f2d4d27ad62792c674d34f24a6d3b460ba96143b78 but actually it seems we had the issue previously