### PR TITLE
fix(deploy): fix HTTP 409 errors when deploying triggers

### DIFF
--- a/deploy/scalewayDeploy.js
+++ b/deploy/scalewayDeploy.js
@@ -77,9 +77,9 @@ class ScalewayDeploy {
       "deploy:deploy": () =>
         BbPromise.bind(this)
           .then(this.createServerlessNamespace)
+          .then(this.updateServerlessNamespace)
           .then(chainContainers)
           .then(chainFunctions)
-          .then(this.updateServerlessNamespace)
           .then(this.deployTriggers),
     };
   }

--- a/shared/setUpDeployment.js
+++ b/shared/setUpDeployment.js
@@ -3,8 +3,8 @@ module.exports = {
     const { service } = this.provider.serverless;
     const { provider } = service;
     this.namespaceName = service.service;
-    this.namespaceVariables = provider.env || {};
-    this.namespaceSecretVariables = provider.secret || {};
+    this.namespaceVariables = provider.env;
+    this.namespaceSecretVariables = provider.secret;
     this.runtime = provider.runtime;
 
     const defaultTokenExpirationDate = new Date();


### PR DESCRIPTION
## Summary

**_What's changed?_**

- Move namespace update to be done before waiting for containers
- Do not provide a default for env vars and secret env vars 

**_Why do we need this?_**

- Currently, deploying triggers is impossible :/
- Why? Well strangely enough, while we do wait for the containers to be `ready` before deploying the triggers, we update the namespace beforehand...
- ...However, with the new API, this also attempts to reload containers if env vars / secret env vars have changed.

This solves the issue in two ways:

-  We wait for the containers for both namespace update + reloading containers in one-go :+1: 
- We do not attempt to patch useless env vars by using a default value :wrench: 

**_How have you tested it?_**

<details>

<summary> Tested locally :white_check_mark:  </summary>

I've reused the `serverless.yml` shown in #324 

```yaml
service: service-name
configValidationMode: warn
useDotenv: true

provider:
  name: scaleway
  scwRegion: nl-ams

plugins:
  - serverless-scaleway-functions

custom:
  containers:
    sync:
      directory: .
      port: 80
      memoryLimit: 1024
      timeout: "300s"
      minScale: 0
      maxScale: 1
      privacy: private
      events:
        - schedule:
            rate: "0,15,30,45 * * * *"
            input: {}
```

Currently, it fails with an obscure 409 errors using `serverless-scaleway-functions@0.5.0`:

```bash
$ npx serverless@3.38.0 deploy
Deployed a new trigger for application sync
✖ Uncaught exception
/home/cyclimse/.npm/_npx/4bb81ea270c57f26/node_modules/serverless/scripts/serverless.js:52
        throw error;
        ^

CustomError: resource is in a transient state
    at manageError (/home/cyclimse/andyreproduce/node_modules/serverless-scaleway-functions/shared/api/utils.js:53:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5) {
  response: {
    status: 409,
    statusText: 'Conflict',
```

Updated `package.json` to point to my local copy with the fix:

```json
{
  "devDependencies": {
    "serverless-scaleway-functions": "file:/home/cyclimse/serverless-scaleway-functions"
  }
}
```

Ran again:

```bash
$ npx serverless@3.38.0 deploy
...
Updating container sync...
Deploying Containers...
Container sync has been deployed to: https://servicename776cd7b8-sync.functions.fnc.nl-ams.scw.cloud
Waiting for domains deployment...
Deploying triggers...
Deployed a new trigger for application sync

Need a faster logging experience than CloudWatch? Try our Dev Mode in Console: run "serverless dev"
```

For reviewers, I tried both update + creation after a `serverless remove`

</details>

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details

Closes #324 