### PR TITLE
chore: bump to 0.5.1 to prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.1
+
+### Fixed
+
+- Deploying triggers no longer lead to an HTTP 409 "transient state" error
+- Do not run into an `undefined` error if the container ends up in a failed state after a deployment
+
 ## 0.5.0
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-scaleway-functions",
-  "version": "0.4.18",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-scaleway-functions",
-      "version": "0.4.18",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@serverless/utils": "^6.13.1",
@@ -71,6 +71,7 @@
       "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1797,6 +1798,7 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2225,6 +2227,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001716",
         "electron-to-chromium": "^1.5.149",
@@ -3416,6 +3419,7 @@
       "integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5542,6 +5546,7 @@
       "resolved": "https://registry.npmjs.org/log/-/log-6.3.2.tgz",
       "integrity": "sha512-ek8NRg/OPvS9ISOJNWNAz5vZcpYacWNFDWNJjj5OXsc6YuKacfey6wF04cXz/tOJIVrZ2nGSkHpAY5qKtF6ISg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d": "^1.0.2",
         "duration": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-scaleway-functions",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Provider plugin for the Serverless Framework v3.x which adds support for Scaleway Functions.",
   "main": "index.js",
   "author": "scaleway.com",

--- a/shared/api/utils.js
+++ b/shared/api/utils.js
@@ -1,7 +1,7 @@
 const axios = require("axios");
 const https = require("https");
 
-const version = "0.5.0";
+const version = "0.5.1";
 
 const invalidArgumentsType = "invalid_arguments";
 


### PR DESCRIPTION
## Summary

**_What's changed?_**

- Bump version to `0.5.1`
- Relock `package-lock.json`
- Update changelog

**_Why do we need this?_**

- Prepare for a release with the fixes from #325 and #326

**_How have you tested it?_**

- N/A

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details
